### PR TITLE
Link to external reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,17 @@ Once installed, see usage details via:
 
 Docere starts with a `report` representing an analysis or a unit of knowledge.
 An analyst can generate their report using any tools they like.
-The only requirement is that their analysis result in a static HTML document.
+The only requirement is that their analysis result in a static HTML document,
+or has a URL.
 
 ## Submit report to a knowledge-repo
 
 All reports are stored in a central git repository, called the `knowledge repository`.
 To submit a new report,
 open a pull request against the knowledge repository.
-Store your report as an `index.html` file in an appropriately named directory.
 
-Add a `report.json` file next to the `index.html` file so docere knows it's a report.
-The `report.json` file is technically optional.
-Docere will still include your report in the rendered documentation.
-However, your report will not be included in any of the metadata pages
-so your report will be difficult to find.
+Create a directory with a `report.json` file.
+If you need a place to serve your report, include it in your pull request.
 
 At a minimum, your `report.json` file should include the following fields:
 
@@ -50,9 +47,12 @@ At a minimum, your `report.json` file should include the following fields:
 * `publish_date`: YYYY-MM-DD format
 * `author`: The author's name
 
-You can optionally specify an `abstract` key, which will be rendered in the TOC.
+Fields that may be optional are:
 
-If desired, this is the time to get review for your analysis.
+* `link`: a URL for an external report
+* `abstract`: an abstract to be rendered in the TOC
+
+If desired, this is an opportunity to get review for your analysis.
 
 ## Render content
 

--- a/docere/render.py
+++ b/docere/render.py
@@ -30,9 +30,12 @@ def _load_report_config(directory):
     for (key, value) in config.items():
         out[key] = value
 
-    # Add directory in which config file was found
-    out['dir'] = directory.path
-    out['path'] = os.path.join(directory.path, out['file'])
+    if 'link' in config:
+        out['path'] = config['link']
+    else:
+        # Add directory in which config file was found
+        out['dir'] = directory.path
+        out['path'] = os.path.join(directory.path, out['file'])
 
     return out
 

--- a/tests/data/kr/some_external_report/report.json
+++ b/tests/data/kr/some_external_report/report.json
@@ -1,0 +1,7 @@
+{
+    "title": "Mozilla Manifesto",
+    "publish_date": "2018-01-01",
+    "author": "Mitchell Baker",
+    "link": "https://www.mozilla.org/en-US/about/manifesto/",
+    "abstract": "The open, global internet is the most powerful communication and collaboration resource we have ever seen."
+}

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -29,6 +29,15 @@ def test_get_reports():
             "path": "tests/data/kr/user_count/index.html",
             "dir": "tests/data/kr/user_count",
         },
+        {
+            "title": "Mozilla Manifesto",
+            "publish_date": "2018-01-01",
+            "author": "Mitchell Baker",
+            "file": "index.html",
+            "link": "https://www.mozilla.org/en-US/about/manifesto/",
+            "path": "https://www.mozilla.org/en-US/about/manifesto/",
+            "abstract": "The open, global internet is the most powerful communication and collaboration resource we have ever seen."
+        }
     ]
 
     assert compare_report_lists(actual, expected)


### PR DESCRIPTION
Allows users to specify a "link:" key in report.json to link to an external report. Fixes https://github.com/mozilla/docere/issues/29.