### PR TITLE
Decorate index page with anchors

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.md
 include tox.ini
 graft docere/plugins/index/templates/
 graft docere/plugins/index/skeleton/
+graft docere/plugins/index/assets/

--- a/docere/plugins/index/__init__.py
+++ b/docere/plugins/index/__init__.py
@@ -1,5 +1,6 @@
 from jinja2 import Environment, FileSystemLoader
 import os
+import re
 import shutil
 
 this_dir, this_filename = os.path.split(__file__)
@@ -11,7 +12,7 @@ TEMPLATE = ENV.get_template('index.html')
 
 
 def build_index(reports, directory='.'):
-    index = TEMPLATE.render(reports=reports)
+    index = TEMPLATE.render(reports=reports, slugify=slugify)
 
     with open(os.path.join(directory, 'index.html'), 'w') as outfile:
         outfile.write(index)
@@ -20,3 +21,15 @@ def build_index(reports, directory='.'):
         os.path.join(this_dir, 'skeleton/css'),
         os.path.join(directory, 'css')
     )
+
+    shutil.copytree(
+        os.path.join(this_dir, 'assets'),
+        os.path.join(directory, 'assets')
+    )
+
+
+def slugify(report):
+    # Returns a string representing the slug for the report.
+    report_title = re.sub(r'[^A-Za-z0-9]+', '', report["title"])[:32]
+    slug = report_title + "_" + report["publish_date"]
+    return slug

--- a/docere/plugins/index/assets/link.svg
+++ b/docere/plugins/index/assets/link.svg
@@ -1,0 +1,4 @@
+<svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-link" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path d="M6.354 5.5H4a3 3 0 0 0 0 6h3a3 3 0 0 0 2.83-4H9c-.086 0-.17.01-.25.031A2 2 0 0 1 7 10.5H4a2 2 0 1 1 0-4h1.535c.218-.376.495-.714.82-1z"/>
+  <path d="M9 5.5a3 3 0 0 0-2.83 4h1.098A2 2 0 0 1 9 6.5h3a2 2 0 1 1 0 4h-1.535a4.02 4.02 0 0 1-.82 1H12a3 3 0 1 0 0-6H9z"/>
+</svg>

--- a/docere/plugins/index/templates/body.html
+++ b/docere/plugins/index/templates/body.html
@@ -18,6 +18,7 @@
     <tr>
       <td>
         <a href="{{report.path}}">{{report.title}}</a>
+        <a name="{{ slugify(report) }}" href="#{{ slugify(report) }}"><img src="assets/link.svg" alt="anchor"></a>
       </td>
       <td>
         {{report.author}}{{ report.authors|join(', ') }}

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,6 +1,8 @@
+import os
+
 from .test_cli import isolated_knowledge_repo
 from docere.render import _get_reports
-from docere.plugins.index import build_index
+from docere.plugins.index import build_index, slugify
 import pytest
 
 
@@ -57,3 +59,17 @@ def test_abstract(reports):
         with open('index.html', 'r') as infile:
             contents = infile.read()
     assert "Lorem ipsum" in contents
+
+
+def test_anchor_link_exists_in_output(reports):
+    with isolated_knowledge_repo(KR, 'kr'):
+        assert not os.path.exists("assets/link.svg")
+        build_index(reports)
+        assert os.path.exists("assets/link.svg")
+        with open('index.html', 'r') as infile:
+            contents = infile.read()
+    assert "a name=" in contents
+
+
+def test_slugify_gives_unique_results(reports):
+    assert len(set(slugify(r) for r in reports)) == len(reports)


### PR DESCRIPTION
Adds anchors to the index page using the Bootstrap link icon.

Looks like:
<img width="893" alt="image" src="https://user-images.githubusercontent.com/173889/98603517-0721e500-2297-11eb-9e4a-878b4d64d315.png">
