### PR TITLE
Add tags to sidebar

### DIFF
--- a/docere/plugins/index/__init__.py
+++ b/docere/plugins/index/__init__.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from jinja2 import Environment, FileSystemLoader
 import os
 import re
@@ -12,6 +13,15 @@ TEMPLATE = ENV.get_template('index.html')
 
 
 def build_index(reports, directory='.'):
+    print(reports)
+    directory = {
+        "product": Counter(),
+        "area": Counter(),
+        "artifact": Counter(),
+        "tags": Counter(),
+    }
+    for report in reports:
+        directory["product"] = report["product"]
     index = TEMPLATE.render(reports=reports, slugify=slugify)
 
     with open(os.path.join(directory, 'index.html'), 'w') as outfile:

--- a/docere/plugins/index/__init__.py
+++ b/docere/plugins/index/__init__.py
@@ -13,16 +13,16 @@ TEMPLATE = ENV.get_template('index.html')
 
 
 def build_index(reports, directory='.'):
-    print(reports)
-    directory = {
-        "product": Counter(),
-        "area": Counter(),
-        "artifact": Counter(),
+    rollup = {
+        "products": Counter(),
+        "areas": Counter(),
+        "artifacts": Counter(),
         "tags": Counter(),
     }
     for report in reports:
-        directory["product"] = report["product"]
-    index = TEMPLATE.render(reports=reports, slugify=slugify)
+        for k in rollup:
+            rollup[k].update(getattr(report, k))
+    index = TEMPLATE.render(reports=reports, slugify=slugify, directory=rollup)
 
     with open(os.path.join(directory, 'index.html'), 'w') as outfile:
         outfile.write(index)
@@ -40,6 +40,6 @@ def build_index(reports, directory='.'):
 
 def slugify(report):
     # Returns a string representing the slug for the report.
-    report_title = re.sub(r'[^A-Za-z0-9]+', '', report["title"])[:32]
-    slug = report_title + "_" + report["publish_date"]
+    report_title = re.sub(r'[^A-Za-z0-9]+', '', report.title)[:32]
+    slug = report_title + "_" + report.publish_date.strftime("%Y-%m-%d")
     return slug

--- a/docere/plugins/index/templates/body.html
+++ b/docere/plugins/index/templates/body.html
@@ -1,5 +1,47 @@
-<h1 style="margin-top:6rem">Report Index</h1>
+<div class="row">
+  <div class="twelve columns">
+    <h1 style="margin-top:6rem">Report Index</h1>
+  </div>
+</div>
 
+<div class="row">
+<div class="sidebar four columns">
+  <!-- give buttons a class name and use CSS to manipulate -->
+  <div class='sidebar_group'>
+    <h4>Products</h4>
+    <ul>
+    {% for product, count in directory.products.most_common() %}
+      <li>{{product}} ({{ count }})</li>
+    {% endfor %}
+    </ul>
+  </div>
+  <div class='sidebar_group'>
+    <h4>Areas</h4>
+    <ul>
+    {% for area, count in directory.areas.most_common() %}
+      <li>{{area}} ({{ count }})</li>
+    {% endfor %}
+  </ul>
+  </div>
+  <div class='sidebar_group'>
+    <h4>Artifact</h4>
+    <ul>
+    {% for artifact, count in directory.artifacts.most_common() %}
+      <li>{{artifact}} ({{ count }})</li>
+    {% endfor %}
+    </ul>
+  </div>
+  <div class='sidebar_group'>
+    <h4>Tags</h4>
+    <ul>
+    {% for tag, count in directory.tags.most_common() %}
+      <li>{{tag}} ({{ count }})</li>
+    {% endfor %}
+  </ul>
+  </div>
+</div>
+
+<div class="eight columns">
 <table class="u-full-width">
   <thead>
     <tr>
@@ -13,15 +55,8 @@
         Publish Date
       </th>
   </thead>
-{% set product_list = [] %}
-{% set artifact_list = [] %}
-{% set area_list = [] %}
-{% set project_list = [] %}
+
 {% for report in reports|sort(attribute='publish_date', reverse=True) %}
-  {{ product_list.append(report.get('product')) | default("", True) }}
-  {{ artifact_list.append(report.get('artifact')) | default("", True) }}
-  {{ area_list.append(report.get('area')) | default("", True) }}
-  {{ project_list.append(report.get('project')) | default("", True) }}
   <tbody>
     <tr>
       <td>
@@ -29,7 +64,7 @@
         <a name="{{ slugify(report) }}" href="#{{ slugify(report) }}"><img src="assets/link.svg" alt="anchor"></a>
       </td>
       <td>
-        {{report.author}}{{ report.authors|join(', ') }}
+        {{ report.authors|join(', ') }}
       </td>
       <td>
         {{report.publish_date}}
@@ -45,61 +80,19 @@
     <tr class="tag-tray">
       <td>
         <span class="tag-label">Product:</span><br>
-        {% if report.product is string %}
-          {{ ([report.product] or ["None"]) | join(",") }}
-        {% elif report.product is not string and report.product is iterable %}
-        {{ report.product | join(",") }}
-        {% endif %}
+        {{ report.products | join(",") or "None"}}
       </td>
       <td>
-        <span class="tag-label">Area:</span><br>
-        {% if report.area is string %}
-          {{ ([report.area] or ["None"]) | join(",") }}
-        {% elif report.area is not string and report.area is iterable %}
-        {{ report.area | join(",") }}
-        {% endif %}
+        <span class="tag-label">Areas:</span><br>
+        {{ report.areas | join(",") or "None" }}
       </td>
       <td>
         <span class="tag-label">Artifact:</span><br>
-        {% if report.artifact is string %}
-          {{ ([report.artifact] or ["None"]) | join(",") }}
-        {% elif report.artifact is not string and report.artifact is iterable %}
-        {{ report.artifact | join(",") }}
-        {% endif %}
+        {{ report.artifacts | join(",") or "None"}}
       </td>
     </tr>
   </tbody>
 {% endfor %}
-<!-- give buttons a class name and use CSS to manipulate -->
-<tr class='sidebar_group'>
-  <h4>Product</h4>
-  {% for entry in product_list | unique %}
-    {% if entry %}
-      <button>{{entry}}</button>
-    {% endif %}
-  {% endfor %}
-</tr>
-<tr class='sidebar_group'>
-  <h4>Area</h4>
-  {% for entry in area_list | unique %}
-    {% if entry %}
-      <button>{{entry}}</button>
-    {% endif %}
-  {% endfor %}
-</tr>
-<tr class='sidebar_group'>
-  <h4>Artifact</h4>
-  {% for entry in artifact_list | unique %}
-    {% if entry %}
-      <button>{{entry}} </button>
-    {% endif %}
-  {% endfor %}
-</tr>
-<tr class='sidebar_group'>
-  <h4>Project</h4>
-  {% for entry in project_list | unique %}
-    {% if entry %}
-      <button>{{entry}}</button>
-    {% endif %}
-    {% endfor %}
-</tr>
+</table>
+</div>
+</div>

--- a/docere/plugins/index/templates/body.html
+++ b/docere/plugins/index/templates/body.html
@@ -13,7 +13,15 @@
         Publish Date
       </th>
   </thead>
+  <!-- check the syntax for inserting an empty list to append content to -->
+  <!-- this is mock code and it's not expected to work right now -->
+<!-- { % tag_list = list()} -->
+<!-- { % topic_list = list()} -->
+{% set tag_list = [] %}
+{% set topic_list = [] %}
 {% for report in reports|sort(attribute='publish_date', reverse=True) %}
+  {{ tag_list.append(report['tags']) if report['tags'] }}
+  {{ topic_list.append(report['topics']) if report['tags'] }}
   <tbody>
     <tr>
       <td>
@@ -50,3 +58,16 @@
     </tr>
   </tbody>
 {% endfor %}
+<!-- give buttons a class name and use CSS to manipulate -->
+<tr class='tag_sidebar'>
+  {% for tag in tag_list %}
+  <button>
+    {{'tag'}}
+  </button>
+  {% endfor %}
+</tr>
+<tr class='topic_sidebar'>
+  {% for topic in topic_list %}
+  <button>{{'topic'}}</button>
+  {% endfor %}
+</tr>

--- a/docere/plugins/index/templates/body.html
+++ b/docere/plugins/index/templates/body.html
@@ -13,15 +13,15 @@
         Publish Date
       </th>
   </thead>
-  <!-- check the syntax for inserting an empty list to append content to -->
-  <!-- this is mock code and it's not expected to work right now -->
-<!-- { % tag_list = list()} -->
-<!-- { % topic_list = list()} -->
-{% set tag_list = [] %}
-{% set topic_list = [] %}
+{% set product_list = [] %}
+{% set artifact_list = [] %}
+{% set area_list = [] %}
+{% set project_list = [] %}
 {% for report in reports|sort(attribute='publish_date', reverse=True) %}
-  {{ tag_list.append(report['tags']) if report['tags'] }}
-  {{ topic_list.append(report['topics']) if report['tags'] }}
+  {{ product_list.append(report.get('product')) | default("", True) }}
+  {{ artifact_list.append(report.get('artifact')) | default("", True) }}
+  {{ area_list.append(report.get('area')) | default("", True) }}
+  {{ project_list.append(report.get('project')) | default("", True) }}
   <tbody>
     <tr>
       <td>
@@ -59,15 +59,35 @@
   </tbody>
 {% endfor %}
 <!-- give buttons a class name and use CSS to manipulate -->
-<tr class='tag_sidebar'>
-  {% for tag in tag_list %}
-  <button>
-    {{'tag'}}
-  </button>
+<tr class='sidebar_group'>
+  <h4>Product</h4>
+  {% for entry in product_list | unique %}
+    {% if entry %}
+      <button>{{entry}}</button>
+    {% endif %}
   {% endfor %}
 </tr>
-<tr class='topic_sidebar'>
-  {% for topic in topic_list %}
-  <button>{{'topic'}}</button>
+<tr class='sidebar_group'>
+  <h4>Area</h4>
+  {% for entry in area_list | unique %}
+    {% if entry %}
+      <button>{{entry}}</button>
+    {% endif %}
   {% endfor %}
+</tr>
+<tr class='sidebar_group'>
+  <h4>Artifact</h4>
+  {% for entry in artifact_list | unique %}
+    {% if entry %}
+      <button>{{entry}} </button>
+    {% endif %}
+  {% endfor %}
+</tr>
+<tr class='sidebar_group'>
+  <h4>Project</h4>
+  {% for entry in project_list | unique %}
+    {% if entry %}
+      <button>{{entry}}</button>
+    {% endif %}
+    {% endfor %}
 </tr>

--- a/docere/plugins/index/templates/body.html
+++ b/docere/plugins/index/templates/body.html
@@ -45,15 +45,27 @@
     <tr class="tag-tray">
       <td>
         <span class="tag-label">Product:</span><br>
-        {{ (report.product or ["None"]) | join(",") }}
+        {% if report.product is string %}
+          {{ ([report.product] or ["None"]) | join(",") }}
+        {% elif report.product is not string and report.product is iterable %}
+        {{ report.product | join(",") }}
+        {% endif %}
       </td>
       <td>
         <span class="tag-label">Area:</span><br>
-        {{ (report.area or ["None"]) | join(",") }}
+        {% if report.area is string %}
+          {{ ([report.area] or ["None"]) | join(",") }}
+        {% elif report.area is not string and report.area is iterable %}
+        {{ report.area | join(",") }}
+        {% endif %}
       </td>
       <td>
         <span class="tag-label">Artifact:</span><br>
-        {{report.artifact}}
+        {% if report.artifact is string %}
+          {{ ([report.artifact] or ["None"]) | join(",") }}
+        {% elif report.artifact is not string and report.artifact is iterable %}
+        {{ report.artifact | join(",") }}
+        {% endif %}
       </td>
     </tr>
   </tbody>

--- a/docere/plugins/index/templates/index.html
+++ b/docere/plugins/index/templates/index.html
@@ -38,9 +38,7 @@
   <!-- Primary Page Layout
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <div class="container">
-    <div class="row">
-      {% include 'body.html' %}
-    </div>
+    {% include 'body.html' %}
   </div>
 
 <!-- End Document

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'jinja2',
         'click',
         'toml',
+        'attrs',
     ],
     tests_require=test_deps,
     extras_require=extras,

--- a/tests/data/kr/json_toml_report/report.json
+++ b/tests/data/kr/json_toml_report/report.json
@@ -2,8 +2,8 @@
     "title": "Just Another JSON Report",
     "publish_date": "2018-01-02",
     "author": "Joe Blow",
-    "product": "firefox-desktop",
-    "area": "accounts",
-    "artifact": "experiment",
-    "project": "important project"
+    "products": "firefox-desktop",
+    "areas": "accounts",
+    "artifacts": "experiment",
+    "tags": "important project"
 }

--- a/tests/data/kr/json_toml_report/report.json
+++ b/tests/data/kr/json_toml_report/report.json
@@ -1,5 +1,9 @@
 {
     "title": "Just Another JSON Report",
     "publish_date": "2018-01-02",
-    "author": "Joe Blow"
+    "author": "Joe Blow",
+    "product": "firefox-desktop",
+    "area": "accounts",
+    "artifact": "experiment",
+    "project": "important project"
 }

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,19 +1,20 @@
 import os
 
 from .test_cli import isolated_knowledge_repo
-from docere.render import _get_reports
+from docere.render import _get_reports, Report
 from docere.plugins.index import build_index, slugify
 import pytest
+from datetime import date
 
 
 KR = 'tests/data/kr'
-EARLY_DATE = "2018-01-01"
-LATE_DATE = "2018-02-01"
+EARLY_DATE = date(2018, 1, 1)
+LATE_DATE = date(2018, 2, 1)
 
 
 @pytest.fixture
 def reports():
-    return(_get_reports(KR))
+    return [Report.from_dict(r) for r in _get_reports(KR)]
 
 
 def get_report_order_with_date_change(reports, dates):
@@ -25,8 +26,8 @@ def get_report_order_with_date_change(reports, dates):
     reports `title` in the resulting `index.html` file.
     """
     with isolated_knowledge_repo(KR, 'kr'):
-        reports[0]['publish_date'] = dates[0]
-        reports[1]['publish_date'] = dates[1]
+        reports[0].publish_date = dates[0]
+        reports[1].publish_date = dates[1]
 
         build_index(reports)
 
@@ -34,8 +35,8 @@ def get_report_order_with_date_change(reports, dates):
             contents = infile.read()
 
     return [
-        contents.index(reports[0]['title']),
-        contents.index(reports[1]['title'])
+        contents.index(reports[0].title),
+        contents.index(reports[1].title)
     ]
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,4 +1,4 @@
-from docere.render import _get_reports, _get_external_reports, tmp_cd
+from docere.render import _get_reports, _get_external_reports, tmp_cd, Report
 import os
 
 
@@ -92,3 +92,18 @@ def test_tmp_cd():
         assert os.getcwd() != basewd
 
     assert os.getcwd() == basewd
+
+
+def test_report_list_conversions():
+    d = {
+        "title": "My report",
+        "publish_date": "2020-02-02",
+        "authors": ["Tim", "Kimmy"],
+        "path": ".",
+        "tags": ["spam", "eggs"],
+        "products": "Fenix",
+    }
+    report = Report.from_dict(d)
+    assert report.products == ["Fenix"]
+    assert report.tags == ["spam", "eggs"]
+    assert report.artifacts == []


### PR DESCRIPTION
Added the buttons and the sidebar which need formatting at a later time. Also fixed some issues we were having with strings being parsed. I did this by checking for every tag (product/area/artifact) if the item was a list or a string and then handling appropriately. The code has a lot of repetition, but maybe that's something we can optimize later on?

Adding a screenshot of how it currently looks.
<img width="813" alt="Screen Shot 2020-12-15 at 1 21 39 PM" src="https://user-images.githubusercontent.com/13249345/102274307-85962600-3ed8-11eb-9e83-6a1a2f1ff4fb.png">
