### PR TITLE
Allow "external report" directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,16 @@ All reports are stored in a central git repository, called the `knowledge reposi
 To submit a new report,
 open a pull request against the knowledge repository.
 
-Create a directory containing a *metadata file* named `report.json` or `report.toml` file.
+You can add your report in either of two ways.
+
+If you need to **use Docere to host HTML**, you should
+create a directory containing a *metadata file* named `report.json` or `report.toml` file.
 ([TOML] is an INI-like configuration format, which is more flexible than JSON.)
-If you need a place to serve your report, include the rendered HTML report in your pull request.
+The rendered HTML should go in the same directory.
+
+If you want to link to **a report that's hosted somewhere else**, like Google Docs,
+then add a .toml or .json file with any name to the external reports directory
+configured for your repository. It's probably named `external`.
 
 At a minimum, your metadata file should include the following fields:
 

--- a/docere/cli.py
+++ b/docere/cli.py
@@ -9,10 +9,15 @@ def cli():
 
 @cli.command()
 @click.option('--knowledge-repo', default='kr', help='Path to knowledge repo')
+@click.option(
+    '--external-reports',
+    default='external',
+    help="Path within the KR that holds external report definitions"
+)
 @click.option('--outdir', default='output',
               help='Desired path for rendered documentation')
-def render(knowledge_repo, outdir):
-    main(knowledge_repo, outdir)
+def render(knowledge_repo, external_reports, outdir):
+    main(knowledge_repo, external_reports, outdir)
 
 
 if __name__ == "__main__":

--- a/docere/render.py
+++ b/docere/render.py
@@ -30,9 +30,14 @@ def _load_report_config(directory):
         with open(config_path, 'r') as infile:
             config = loader(infile)
         break
+    else:
+        raise ValueError(
+            f"Thought there was a valid config file in {directory} but couldn't find one"
+        )
 
     # Set defaults
     out = REPORT_DEFAULTS.copy()
+    out['source'] = config_path
     for (key, value) in config.items():
         out[key] = value
 

--- a/tests/data/kr/external/nested/test2.json
+++ b/tests/data/kr/external/nested/test2.json
@@ -1,0 +1,6 @@
+{
+    "title": "A nested external report",
+    "author": "Fire Q. Fox",
+    "publish_date": "1999-02-14",
+    "link": "https://letsencrypt.org"
+}

--- a/tests/data/kr/external/test1.toml
+++ b/tests/data/kr/external/test1.toml
@@ -1,0 +1,4 @@
+author = "Somebody"
+publish_date = "2020-01-01"
+title = "An external report"
+link = "https://example.com"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,8 @@ def isolated_knowledge_repo(kr_path, iso_path):
 def test_render():
     runner = CliRunner()
     with isolated_knowledge_repo('tests/data/kr', 'kr'):
-        runner.invoke(render, ['--knowledge-repo', 'kr'])
+        result = runner.invoke(render, ['--knowledge-repo', 'kr'], catch_exceptions=False)
+        assert result.exit_code == 0
         assert os.path.isfile('output/user_count/index.html')
         assert os.path.isfile('output/user_count/report.json')
 
@@ -35,7 +36,8 @@ def test_render():
 def test_index():
     runner = CliRunner()
     with isolated_knowledge_repo('tests/data/kr', 'kr'):
-        runner.invoke(render, ['--knowledge-repo', 'kr'])
+        result = runner.invoke(render, ['--knowledge-repo', 'kr'], catch_exceptions=False)
+        assert result.exit_code == 0
         assert os.path.isfile('output/index.html')
 
         with open('output/index.html', 'r') as infile:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -2,11 +2,21 @@ from docere.render import _get_reports, tmp_cd
 import os
 
 
-def compare_report_lists(this, that):
-    return (
-        all([report in this for report in that]) and
-        all([report in that for report in this])
-    )
+def contains_at_least(actual, expected):
+    """Asserts that all reports that appear in `expected` appear in `actual`.
+    All fields defined on the expected report must match exactly on the actual report.
+    There are allowed to be extra reports in `actual` and the actual reports
+    are allowed to have extra fields.
+    """
+    actual_by_source = {d["source"]: d for d in actual}
+    expected_by_source = {d["source"]: d for d in expected}
+    assert len(actual_by_source) == len(actual)
+    assert len(expected_by_source) == len(expected)
+    for source, expected_report in expected_by_source.items():
+        actual_report = actual_by_source[source]
+        for key in expected_report:
+            assert actual_report[key] == expected_report[key]
+    return True
 
 
 def test_get_reports():
@@ -17,6 +27,7 @@ def test_get_reports():
             "publish_date": "2018-01-01",
             "author": "Joseph Blowseph",
             "file": "not_index.html",
+            "source": "tests/data/kr/crash_count/report.json",
             "path": "tests/data/kr/crash_count/not_index.html",
             "dir": "tests/data/kr/crash_count",
             "abstract": "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
@@ -26,6 +37,7 @@ def test_get_reports():
             "publish_date": "2018-01-02",
             "author": "Joe Blow",
             "file": "index.html",
+            "source": "tests/data/kr/user_count/report.json",
             "path": "tests/data/kr/user_count/index.html",
             "dir": "tests/data/kr/user_count",
         },
@@ -34,6 +46,7 @@ def test_get_reports():
             "publish_date": "2018-01-01",
             "author": "Mitchell Baker",
             "file": "index.html",
+            "source": "tests/data/kr/some_external_report/report.json",
             "link": "https://www.mozilla.org/en-US/about/manifesto/",
             "path": "https://www.mozilla.org/en-US/about/manifesto/",
             "abstract": "The open, global internet is the most powerful communication and collaboration resource we have ever seen."  # noqa:E501
@@ -43,6 +56,7 @@ def test_get_reports():
             "publish_date": "2018-01-02",
             "author": "Tom",
             "file": "index.html",
+            "source": "tests/data/kr/toml_report/report.toml",
             "path": "tests/data/kr/toml_report/index.html",
             "dir": "tests/data/kr/toml_report",
         },
@@ -51,12 +65,13 @@ def test_get_reports():
             "publish_date": "2018-01-02",
             "author": "Joe Blow",
             "file": "index.html",
+            "source": "tests/data/kr/json_toml_report/report.json",
             "path": "tests/data/kr/json_toml_report/index.html",
             "dir": "tests/data/kr/json_toml_report",
         },
     ]
 
-    assert compare_report_lists(actual, expected)
+    assert contains_at_least(actual, expected)
 
 
 def test_tmp_cd():

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,4 +1,4 @@
-from docere.render import _get_reports, tmp_cd
+from docere.render import _get_reports, _get_external_reports, tmp_cd
 import os
 
 
@@ -13,6 +13,7 @@ def contains_at_least(actual, expected):
     assert len(actual_by_source) == len(actual)
     assert len(expected_by_source) == len(expected)
     for source, expected_report in expected_by_source.items():
+        assert source in actual_by_source.keys()
         actual_report = actual_by_source[source]
         for key in expected_report:
             assert actual_report[key] == expected_report[key]
@@ -68,10 +69,21 @@ def test_get_reports():
             "source": "tests/data/kr/json_toml_report/report.json",
             "path": "tests/data/kr/json_toml_report/index.html",
             "dir": "tests/data/kr/json_toml_report",
-        },
+        }
     ]
 
     assert contains_at_least(actual, expected)
+
+    external = [
+        {
+            "source": "tests/data/kr/external/test1.toml",
+        },
+        {
+            "source": "tests/data/kr/external/nested/test2.json",
+        }
+    ]
+
+    assert contains_at_least(_get_external_reports("tests/data/kr/external"), external)
 
 
 def test_tmp_cd():


### PR DESCRIPTION
Instead of requiring each report to be in its own folder, introduce an "external reports folder" where any .toml or .json file is assumed to be a valid report definition file.

Also makes test_get_reports more flexible.

Closes #42, closes #47.